### PR TITLE
Performance improvement (replacing new RegExp)

### DIFF
--- a/underscore-get.js
+++ b/underscore-get.js
@@ -3,7 +3,7 @@ module.exports = function get(obj, desc, value) {
 
   while (arr.length && obj) {
     var comp = arr.shift();
-    var match = new RegExp("(.+)\\[([0-9]*)\\]").exec(comp);
+    var match = /(.+)\[([0-9]*)\]/.exec(comp);
 
     // handle arrays
     if ((match !== null) && (match.length == 3)) {


### PR DESCRIPTION
With literal syntax the regular expression is created one time during initial code parsing and compiling, while the new RegExp() syntax create it every time (and using that syntax inside the while loop is even worse in terms of performance).

Full explanation here: https://stackoverflow.com/a/32523333/146513